### PR TITLE
[추가 구현] 학생은 구독 중인 학교 소식을 자신의 뉴스피드에서 모아볼 수 있다.((issue#14)

### DIFF
--- a/news-feed/src/docs/asciidoc/index.adoc
+++ b/news-feed/src/docs/asciidoc/index.adoc
@@ -209,6 +209,38 @@ include::build/generated-snippets/schoolnews-delete/http-response.adoc[]
 '학교소식 뉴스피드'의 학교 구독 여부
 
 
+== SchoolNewsDelivery
+
+학교소식 배송(피드)
+[[SchoolNewsDelivery-mynewsfeed]]
+=== SchoolNewsDelivery(my-news-feed)
+
+*[GET] http://base-url/school-news-delivery/my-news-feed*
+
+* 유저가 구독한 모든 학교의 학교 소식을 모아보기할 수 있다.
+** 학교 소식이 노출되는 뉴스피드는 최신순으로 소식을 노출됨.
+** 유저는 학교 페이지를 구독하는 시점 이후 소식부터 뉴스피드를 받음
+** 학교 페이지 구독을 취소해도 기존 뉴스피드에 나타난 소식은 유지됨.
+
+==== HTTP request
+
+include::build/generated-snippets/schoolnewsdelivery-mynewsfeed/http-request.adoc[]
+
+
+
+==== HTTP response
+include::build/generated-snippets/schoolnewsdelivery-mynewsfeed/response-fields.adoc[]
+include::build/generated-snippets/schoolnewsdelivery-mynewsfeed/http-response.adoc[]
+* 성공했을 경우 200 반환
+* 실패했을 경우 400 반환 (예: 로그인을 하지 않아, 유저 정보가 없을 때)
+
+
+
+
+
+== SchoolSubscribe
+학교소식 구독
+
 
 [[SchoolSubscribe-create]]
 === SchoolSubscribe 생성

--- a/news-feed/src/main/java/com/school/newsfeed/common/config/AsyncConfig.java
+++ b/news-feed/src/main/java/com/school/newsfeed/common/config/AsyncConfig.java
@@ -10,15 +10,4 @@ import java.util.concurrent.Executor;
 @EnableAsync
 @Configuration
 public class AsyncConfig implements AsyncConfigurer {
-    @Override
-    public Executor getAsyncExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(5);
-        executor.setMaxPoolSize(5);
-        executor.setQueueCapacity(5);
-        executor.setKeepAliveSeconds(30);
-        executor.setThreadNamePrefix("async-executor-");
-        executor.initialize();
-        return executor;
-    }
 }

--- a/news-feed/src/main/java/com/school/newsfeed/common/config/QuerydslConfiguration.java
+++ b/news-feed/src/main/java/com/school/newsfeed/common/config/QuerydslConfiguration.java
@@ -1,0 +1,19 @@
+package com.school.newsfeed.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewDeliveryController.java
+++ b/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewDeliveryController.java
@@ -1,0 +1,27 @@
+package com.school.newsfeed.domain.schoolnewsdelivery;
+
+import com.school.newsfeed.domain.schoolnewsdelivery.dto.MyFeed;
+import com.school.newsfeed.domain.user.dto.LoginUserDto;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/school-news-delivery")
+public class SchoolNewDeliveryController {
+    private final SchoolNewsDeliveryService deliveryService;
+
+    @GetMapping("/my-news-feed")
+    public ResponseEntity getMyFeed(HttpSession session){
+        LoginUserDto user = (LoginUserDto) session.getAttribute("loginUser");
+        if (user==null) return ResponseEntity.badRequest().build();
+        List<MyFeed> result = deliveryService.getMyFeed(user);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewsDeliveryHandler.java
+++ b/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewsDeliveryHandler.java
@@ -3,6 +3,7 @@ package com.school.newsfeed.domain.schoolnewsdelivery;
 import com.school.newsfeed.domain.schoolsubscribe.SchoolSubscribe;
 import com.school.newsfeed.domain.schoolsubscribe.SchoolSubscribeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -19,10 +20,9 @@ public class SchoolNewsDeliveryHandler {
     private final SchoolNewsDeliveryRepository deliveryRepository;
 
     /**
-     * 학교_소식 생성 후, 실제 구독자들에게 학교_소식_배송 (구독자가 늘어날 수록 무거워지기때문에 비동기로 실행함)
+     * 학교_소식 생성 후, 실제 구독자들에게 학교_소식_배송 (구독자가 늘어날 수록 무거워지기때문에 비동기로 실행 검토 필요 )
      */
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
+    @EventListener
     public void eventHandler(SchoolNewsDelivery deliveryEvent){
         List<SchoolSubscribe> activeSubscribes = subscribeRepository.findAllBySchoolIdAndDel(deliveryEvent.getSchoolId(),false);
         List<SchoolNewsDelivery> realDeliveries = new ArrayList<>();

--- a/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewsDeliveryHandler.java
+++ b/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewsDeliveryHandler.java
@@ -1,13 +1,11 @@
 package com.school.newsfeed.domain.schoolnewsdelivery;
 
+import com.school.newsfeed.domain.schoolnewsdelivery.repository.SchoolNewsDeliveryRepository;
 import com.school.newsfeed.domain.schoolsubscribe.SchoolSubscribe;
 import com.school.newsfeed.domain.schoolsubscribe.SchoolSubscribeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewsDeliveryRepository.java
+++ b/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewsDeliveryRepository.java
@@ -1,11 +1,12 @@
 package com.school.newsfeed.domain.schoolnewsdelivery;
 
 import com.school.newsfeed.domain.schoolnews.SchoolNews;
+import com.school.newsfeed.domain.schoolnewsdelivery.repository.SchoolNewsDeliveryRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
 @Repository
-public interface SchoolNewsDeliveryRepository extends JpaRepository<SchoolNewsDelivery, UUID> {
+public interface SchoolNewsDeliveryRepository extends JpaRepository<SchoolNewsDelivery, UUID>, SchoolNewsDeliveryRepositoryCustom {
 }

--- a/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewsDeliveryService.java
+++ b/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewsDeliveryService.java
@@ -1,0 +1,18 @@
+package com.school.newsfeed.domain.schoolnewsdelivery;
+
+import com.school.newsfeed.domain.schoolnewsdelivery.dto.MyFeed;
+import com.school.newsfeed.domain.user.dto.LoginUserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SchoolNewsDeliveryService {
+    private final SchoolNewsDeliveryRepository deliveryRepository;
+    public List<MyFeed> getMyFeed(LoginUserDto user){
+        List<MyFeed> result = deliveryRepository.getFeed(user.getUserId());
+        return result;
+    }
+}

--- a/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewsDeliveryService.java
+++ b/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewsDeliveryService.java
@@ -1,6 +1,7 @@
 package com.school.newsfeed.domain.schoolnewsdelivery;
 
 import com.school.newsfeed.domain.schoolnewsdelivery.dto.MyFeed;
+import com.school.newsfeed.domain.schoolnewsdelivery.repository.SchoolNewsDeliveryRepository;
 import com.school.newsfeed.domain.user.dto.LoginUserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/dto/MyFeed.java
+++ b/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/dto/MyFeed.java
@@ -1,0 +1,32 @@
+package com.school.newsfeed.domain.schoolnewsdelivery.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+public class MyFeed {
+    private UUID deliveryId;
+    private LocalDateTime deliveryCreatedDate;
+    private UUID schoolId;
+    private String SchoolName;
+    private UUID schoolNewId;
+    private String SchoolNewsTitle;
+    private String SchoolNewsContents;
+
+    @QueryProjection
+    public MyFeed(UUID deliveryId, LocalDateTime deliveryCreatedDate, UUID schoolId,
+                  String schoolName, UUID schoolNewId,
+                  String schoolNewsTitle, String schoolNewsContents) {
+        this.deliveryId = deliveryId;
+        this.deliveryCreatedDate = deliveryCreatedDate;
+        this.schoolId = schoolId;
+        SchoolName = schoolName;
+        this.schoolNewId = schoolNewId;
+        SchoolNewsTitle = schoolNewsTitle;
+    }
+}

--- a/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/dto/MyFeed.java
+++ b/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/dto/MyFeed.java
@@ -13,20 +13,21 @@ public class MyFeed {
     private UUID deliveryId;
     private LocalDateTime deliveryCreatedDate;
     private UUID schoolId;
-    private String SchoolName;
-    private UUID schoolNewId;
-    private String SchoolNewsTitle;
-    private String SchoolNewsContents;
+    private String schoolName;
+    private UUID schoolNewsId;
+    private String schoolNewsTitle;
+    private String schoolNewsContent;
 
     @QueryProjection
     public MyFeed(UUID deliveryId, LocalDateTime deliveryCreatedDate, UUID schoolId,
                   String schoolName, UUID schoolNewId,
-                  String schoolNewsTitle, String schoolNewsContents) {
+                  String schoolNewsTitle, String schoolNewsContent) {
         this.deliveryId = deliveryId;
         this.deliveryCreatedDate = deliveryCreatedDate;
         this.schoolId = schoolId;
-        SchoolName = schoolName;
-        this.schoolNewId = schoolNewId;
-        SchoolNewsTitle = schoolNewsTitle;
+        this.schoolName = schoolName;
+        this.schoolNewsId = schoolNewId;
+        this.schoolNewsTitle = schoolNewsTitle;
+        this.schoolNewsContent = schoolNewsContent;
     }
 }

--- a/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/repository/SchoolNewsDeliveryRepository.java
+++ b/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/repository/SchoolNewsDeliveryRepository.java
@@ -1,6 +1,7 @@
-package com.school.newsfeed.domain.schoolnewsdelivery;
+package com.school.newsfeed.domain.schoolnewsdelivery.repository;
 
 import com.school.newsfeed.domain.schoolnews.SchoolNews;
+import com.school.newsfeed.domain.schoolnewsdelivery.SchoolNewsDelivery;
 import com.school.newsfeed.domain.schoolnewsdelivery.repository.SchoolNewsDeliveryRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/repository/SchoolNewsDeliveryRepositoryCustom.java
+++ b/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/repository/SchoolNewsDeliveryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.school.newsfeed.domain.schoolnewsdelivery.repository;
+
+import com.school.newsfeed.domain.schoolnewsdelivery.dto.MyFeed;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface SchoolNewsDeliveryRepositoryCustom {
+    List<MyFeed> getFeed(UUID userId);
+}

--- a/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/repository/SchoolNewsDeliveryRepositoryImpl.java
+++ b/news-feed/src/main/java/com/school/newsfeed/domain/schoolnewsdelivery/repository/SchoolNewsDeliveryRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.school.newsfeed.domain.schoolnewsdelivery.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.school.newsfeed.domain.schoolnewsdelivery.dto.MyFeed;
+
+import com.school.newsfeed.domain.schoolnewsdelivery.dto.QMyFeed;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.school.newsfeed.domain.school.QSchool.school;
+import static com.school.newsfeed.domain.schoolnews.QSchoolNews.schoolNews;
+import static com.school.newsfeed.domain.schoolnewsdelivery.QSchoolNewsDelivery.schoolNewsDelivery;
+
+
+@RequiredArgsConstructor
+public class SchoolNewsDeliveryRepositoryImpl implements SchoolNewsDeliveryRepositoryCustom {
+    private  final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MyFeed> getFeed(UUID userId) {
+        UUID userid = UUID.fromString(userId.toString()); //알수 없는 이유로 빨간줄 떠서 일단 이렇게 처리
+        List<MyFeed> result = queryFactory.select(new QMyFeed(schoolNewsDelivery.id, schoolNewsDelivery.createdDate,
+                        schoolNewsDelivery.schoolId, school.name,
+                        schoolNewsDelivery.schoolNewsId, schoolNews.title, schoolNews.content))
+                .from(schoolNewsDelivery)
+                .where(schoolNewsDelivery.userId.eq(userid))
+                .leftJoin(school)
+                .on(schoolNewsDelivery.schoolId.eq(school.id))
+                .leftJoin(schoolNews)
+                .on(schoolNewsDelivery.schoolNewsId.eq(schoolNews.id))
+                .orderBy(schoolNewsDelivery.createdDate.desc())
+                .fetch();
+        return result;
+    }
+}

--- a/news-feed/src/test/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewDeliveryControllerTest.java
+++ b/news-feed/src/test/java/com/school/newsfeed/domain/schoolnewsdelivery/SchoolNewDeliveryControllerTest.java
@@ -1,0 +1,118 @@
+package com.school.newsfeed.domain.schoolnewsdelivery;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import com.school.newsfeed.NewsFeedApplication;
+import com.school.newsfeed.domain.school.Area;
+import com.school.newsfeed.domain.school.SchoolType;
+import com.school.newsfeed.domain.school.dto.MakeSchoolDto;
+import com.school.newsfeed.domain.schoolnews.dto.MakeSchoolNewsDto;
+import com.school.newsfeed.domain.user.UserType;
+import com.school.newsfeed.domain.user.dto.LoginUserDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.UUID;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = NewsFeedApplication.class)
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+public class SchoolNewDeliveryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    private MockHttpSession mockSession;
+    private ObjectMapper mapper;
+    private  final String managerEmail = "m2@test.com";
+    private  final String studentEmail = "s1@test.com";
+    //2개의 세션 권한을 번갈아 써야하기때문에 임의로 ID값 고정
+    private  final String managerUUID = "e129560a-c6d1-43c7-8e58-ccce95e355b9";
+    private  final String studentUUID = "fbc63b89-7110-432b-ac8a-e55be8c20afd";
+
+    private String schoolId;
+    public void setSessionAsSchoolManager(){
+        mockSession=new MockHttpSession();
+        mockSession.setAttribute("loginUser", new LoginUserDto(UUID.fromString(managerUUID),  managerEmail, "김관리자", UserType.SCHOOL_MANAGER));
+    }
+
+    public void setSessionAsStudent(){
+        mockSession=new MockHttpSession();
+        mockSession.setAttribute("loginUser", new LoginUserDto(UUID.fromString(studentUUID), studentEmail,"김학생",  UserType.STUDENT));
+    }
+
+    @Test
+    public void contextLoad() throws Exception {
+        mapper = new ObjectMapper();
+        //given
+        setSessionAsSchoolManager();// 1: 학교 관리자A 권한으로 학교 생성
+        createSchoolByManager("뉴스피드초등학교");
+        createSchoolNews(schoolId);//학교소식1 생성(구독한 학생이 없기때문에 이 학교소식은 my-news-feed에 표시 안됨)
+
+        setSessionAsStudent();//2. 학생B 계정으로 구독함
+        createSchoolSubscribes(schoolId);
+
+        setSessionAsSchoolManager();// 3: 학교 관리자A 권한으로 돌아와서 학교소식2 생성
+        createSchoolNews(schoolId);//(학생B는 이전 시점에 구독했기때문에 이 건에 대한 feed만 확인가능)
+
+        //when
+        setSessionAsStudent();
+        //then
+        getMyNewsFeed(); //적중 피드 1건
+    }
+
+    private void getMyNewsFeed()throws Exception{
+        mockMvc.perform(get("/school-news-delivery/my-news-feed").session(mockSession))
+                .andExpect(status().isOk())
+                .andDo(document("schoolnewsdelivery-mynewsfeed",
+                        responseFields(
+                                fieldWithPath("[].deliveryId").description("피드배달 UUID"),
+                                fieldWithPath("[].deliveryCreatedDate").description("피드배달 생성시각"),
+                                fieldWithPath("[].schoolId").description("학교 UUID"),
+                                fieldWithPath("[].schoolName").description("학교 이름"),
+                                fieldWithPath("[].schoolNewsId").description("학교소식 UUID"),
+                                fieldWithPath("[].schoolNewsTitle").description("학교소식 제목"),
+                                fieldWithPath("[].schoolNewsContent").description("학교소식 본문"))));
+    }
+    private void createSchoolSubscribes(String schoolId) throws Exception{
+        this.mockMvc
+                .perform(post("/school-subscribe/school/{schoolId}", schoolId)
+                        .queryParam("schoolId",schoolId).session(mockSession)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    private void createSchoolByManager(String schoolName) throws Exception {
+        MakeSchoolDto request = new MakeSchoolDto(schoolName, "세종특별자치시 소담1로 35", SchoolType.ELEMENTARY, Area.SEJONG);
+        String jsonRequest = mapper.writeValueAsString(request);
+        MvcResult response= this.mockMvc
+                .perform(post("/school").session(mockSession)
+                        .content(jsonRequest)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk()).andReturn();
+        schoolId= JsonPath.parse(response.getResponse().getContentAsString()).read("id");
+    }
+
+    public void createSchoolNews(String schoolId) throws Exception{
+        MakeSchoolNewsDto request = new MakeSchoolNewsDto(UUID.fromString(schoolId), "2024년 운영 안내", "2024년은 1학기와 2학기로 운영됩니다.(본문 내용 이어짐..)");
+        String jsonRequest = mapper.writeValueAsString(request);
+        this.mockMvc
+                .perform(post("/school-news").session(mockSession)
+                        .content(jsonRequest)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
↑ 위 기능을 실행하기 위한 API 1개를 추가했습니다.
학생은 구독 중인 학교 소식을 자신의 뉴스피드에서 모아볼 수 있다.

#### [SchoolNewsDelivery](http://localhost:5000/#_schoolnewsdelivery)
[SchoolNewsDelivery(my-news-feed)](http://localhost:5000/#SchoolNewsDelivery-mynewsfeed)


chores: 
- SchoolNews 생성 이벤트 이후, 비동기로 발행하던 SchoolNewsDelivery 생성 로직 원상복귀 (테스트 환경에서 제때 안 보내지는 문제가 있음_
- QueryDsl 사용관련 추가 설정